### PR TITLE
Consistent package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "type": "module",
-  "engines": {
-    "node": "^16 || >=18"
+  "private": true,
+  "dependencies": {
+    "@fastly/js-compute": "^3.33.2"
   },
   "devDependencies": {
-    "@fastly/cli": "^10.14.0",
+    "@fastly/cli": "^11.0.0",
     "typescript": "^5.2.2"
-  },
-  "dependencies": {
-    "@fastly/js-compute": "^3.7.0"
   },
   "scripts": {
     "prebuild": "tsc",


### PR DESCRIPTION
This PR makes package.json consistent across the various JavaScript (TypeScript) starter kits.

1. As this is a template, removes fields that we would not want downstream projects to inherit if they were set:
   * package name, author, bugs, homepage, repository, license, version

2. As the package created from the template is an application:
   * sets private: true
   * removes main if it was set

3. Removes any engine requirement, as it is unneeded (and has been removed from js-compute since 3.14.0 as well).

4. Updates @fastly/cli to version ^11.0.0 (latest major release) and @fastly/js-compute to ^3.33.2 (includes latest crash fix)
   * if package depends on webpack, updates it to ^5.98.0, which includes a security fix

5. Places `dependencies`, `devDependencies`, `scripts` consistently in this order.
